### PR TITLE
don't overflow the stack

### DIFF
--- a/src/AttributeSet.ts
+++ b/src/AttributeSet.ts
@@ -68,7 +68,10 @@ export class StringAttribute implements DecoratedAttribute {
 
         const valueLength = arr[2 + nameLength]
         const valueBytes = arr.slice(3 + nameLength)
-        const value = String.fromCharCode(...valueBytes)
+        let value = '' // String.fromCharCode(...valueBytes)
+        for (const byte of valueBytes) {
+            value += String.fromCharCode(byte)
+        }
         return new StringAttribute(name, value)
     }
 }

--- a/src/__tests__/attribute.test.ts
+++ b/src/__tests__/attribute.test.ts
@@ -6,7 +6,7 @@
  *  Licensed under GPL v3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
  *
  */
-import { AttributeSet, AttributeType } from '../AttributeSet'
+import { AttributeSet, AttributeType, StringAttribute } from '../AttributeSet'
 
 const testjson = {
     aBool: false,
@@ -33,4 +33,12 @@ test('to and from JSON', () => {
 
     expect(as.indexOfAttribute('motto')).toBe(2)
     expect(as2.indexOfAttribute('num')).toBe(3)
+})
+
+test(`encode/decode large strings`, () => {
+    const bigArray = new Array(200000).fill(88)
+    const prefix = [0, 1, 88, 20000]
+    const bigAttr = [...prefix, ...bigArray]
+    const strattr = StringAttribute.decode(bigAttr)
+    console.log({ strattr: { name: strattr.name, val: strattr.value.slice(0, 20), len: strattr.value.length } })
 })


### PR DESCRIPTION
big strings shouldn't break attribute decoding